### PR TITLE
Guard Advanced Vector Extensions 2.0 (AVX2) (Haswell-)specific Optimizations with the Appropriate Preprocessor Guards

### DIFF
--- a/src/hex.cc
+++ b/src/hex.cc
@@ -62,6 +62,7 @@ static inline int8_t unhexB(uint8_t x) { return unhex_table[x]; }
 // Looks up the value for the upper nibble. Equivalent to `unhexB(x) << 4`.
 static inline int8_t unhexA(uint8_t x) { return unhex_table4[x]; }
 
+#if defined(__AVX2__)
 static inline int8_t unhexBitManip(uint8_t x) {
   return 9 * (x >> 6) + (x & 0xf);
 }
@@ -95,10 +96,6 @@ inline static __m256i unhexBitManip(const __m256i value) {
   return add;
 }
 
-static const char hex_table[16] = {
-  '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
-};
-inline static char hex(uint8_t value) { return hex_table[value]; }
 static const __m256i HEX_LUTR = _mm256_setr_epi8(
   '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
   '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f');
@@ -182,6 +179,7 @@ void decodeHexVec(uint8_t* __restrict__ dest, const uint8_t* __restrict__ src, s
   dest = reinterpret_cast<uint8_t*>(dec256);
   decodeHexBMI(dest, src, len);
 }
+#endif // defined(__AVX2__)
 
 // len is number of dest bytes
 void decodeHexLUT(uint8_t* __restrict__ dest, const uint8_t* __restrict__ src, size_t len) {
@@ -205,6 +203,11 @@ void decodeHexLUT4(uint8_t* __restrict__ dest, const uint8_t* __restrict__ src, 
   }
 }
 
+static const char hex_table[16] = {
+  '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
+};
+inline static char hex(uint8_t value) { return hex_table[value]; }
+
 // len is number of src bytes
 void encodeHex(uint8_t* __restrict__ dest, const uint8_t* __restrict__ src, size_t len) {
   for (size_t i = 0; i < len; i++) {
@@ -216,6 +219,7 @@ void encodeHex(uint8_t* __restrict__ dest, const uint8_t* __restrict__ src, size
   }
 }
 
+#if defined(__AVX2__)
 // len is number of src bytes
 void encodeHexVec(uint8_t* __restrict__ dest, const uint8_t* __restrict__ src, size_t len) {
   const __m128i* input128 = reinterpret_cast<const __m128i*>(src);
@@ -232,3 +236,4 @@ void encodeHexVec(uint8_t* __restrict__ dest, const uint8_t* __restrict__ src, s
 
   encodeHex(dest + (vectLen << 5), src + (vectLen << 4), tailLen);
 }
+#endif // defined(__AVX2__)

--- a/src/hex.h
+++ b/src/hex.h
@@ -16,8 +16,10 @@ void decodeHexLUT(uint8_t* __restrict__ dest, const uint8_t* __restrict__ src, s
 // Optimized scalar look-up table version (avoids a shift). len is number of dest bytes (1/2 the size of src).
 void decodeHexLUT4(uint8_t* __restrict__ dest, const uint8_t* __restrict__ src, size_t len);
 
+#if defined(__AVX2__)
 // Optimal AVX2 vectorized version. len is number of dest bytes (1/2 the size of src).
 void decodeHexVec(uint8_t* __restrict__ dest, const uint8_t* __restrict__ src, size_t len);
+#endif // defined(__AVX2__)
 
 // Encoders
 // Encode src bytes into dest hex string
@@ -25,5 +27,7 @@ void decodeHexVec(uint8_t* __restrict__ dest, const uint8_t* __restrict__ src, s
 // Scalar version. len is number of src bytes. dest must be twice the size of src.
 void encodeHex(uint8_t* __restrict__ dest, const uint8_t* __restrict__ src, size_t len);
 
+#if defined(__AVX2__)
 // AVX2 vectorized version. len is number of src bytes. dest must be twice the size of src.
 void encodeHexVec(uint8_t* __restrict__ dest, const uint8_t* __restrict__ src, size_t len);
+#endif // defined(__AVX2__)


### PR DESCRIPTION
This addresses #8 by wrapping Advanced Vector Extensions 2.0 (AVX2)-specific code with '__AVX2__' preprocessor guards that are only asserted when `-march=haswell` has been specified.